### PR TITLE
chore: add devcontainer for easier contributions

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,7 @@
     "PRETALX_CONFIG_FILE": "${containerWorkspaceFolder}/.devcontainer/pretalx.cfg",
     "DJANGO_SUPERUSER_EMAIL": "superuser@pretalx.local",
     "DJANGO_SUPERUSER_PASSWORD": "pretalx",
-    "PRETALX_INIT_ORGANISER_NAME": "The Organisers",
+    "PRETALX_INIT_ORGANISER_NAME": "The Organizers",
     "PRETALX_INIT_ORGANISER_SLUG": "localorg",
   },
   "customizations": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,30 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/python
+{
+  "name": "pretalx-devcontainer",
+  "dockerComposeFile": "docker-compose.yml",
+  "service": "devcontainer",
+  "workspaceFolder": "/workspace",
+  "postCreateCommand": "/opt/pretalx-devcontainer/default-scripts/plugin-development/post-create.sh && ${containerWorkspaceFolder}/.devcontainer/post-create.sh",
+  "postStartCommand": "/opt/pretalx-devcontainer/default-scripts/plugin-development/post-start.sh && ${containerWorkspaceFolder}/.devcontainer/post-start.sh",
+  "containerEnv": {
+    "PRETALX_DATA_DIR": "${containerWorkspaceFolder}/.devcontainer/local",
+    "PRETALX_CONFIG_FILE": "${containerWorkspaceFolder}/.devcontainer/pretalx.cfg",
+    "DJANGO_SUPERUSER_EMAIL": "superuser@pretalx.local",
+    "DJANGO_SUPERUSER_PASSWORD": "pretalx",
+    "PRETALX_INIT_ORGANISER_NAME": "The Organisers",
+    "PRETALX_INIT_ORGANISER_SLUG": "localorg",
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "ms-python.debugpy"
+      ]
+    }
+  },
+  "forwardPorts": [
+    8000,
+    9400
+  ]
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   devcontainer:
-    image: ghcr.io/tjarbo/pretalx-devcontainer/devcontainer:main
+    image: ghcr.io/tjarbo/pretalx-devcontainer/devcontainer:v2
     network_mode: "service:oidc-provider-mock"
     volumes:
       - ../:/workspace:cached
@@ -12,4 +12,4 @@ services:
       - "9400:9400"
     command:
       - "--user-claims"
-      - '{"sub": "alice", "email": "alice@example.com", "name": "Alice"}'
+      - '{"sub": "alice", "email": "alice@dev.pretalx.local", "name": "Alice"}'

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+  devcontainer:
+    image: ghcr.io/tjarbo/pretalx-devcontainer/devcontainer:main
+    network_mode: "service:oidc-provider-mock"
+    volumes:
+      - ../:/workspace:cached
+    command: sleep infinity
+  
+  oidc-provider-mock:
+    image: ghcr.io/tjarbo/oidc-provider-mock:f96d2559e57533ac45587973de7a51c1dfbb9473
+    ports:
+      - "9400:9400"
+    command:
+      - "--user-claims"
+      - '{"sub": "alice", "email": "alice@example.com", "name": "Alice"}'

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+# Plugin specific post-create.sh script.
+GREEN="\033[1;32m"
+YELLOW="\033[1;33m"
+RED="\033[1;31m"
+RESET="\033[0m"
+
+echo "${YELLOW}ℹ Current working directory: $(pwd)${RESET}"
+echo "${YELLOW}ℹ Initalizing pretalx.${RESET}"
+echo "------"
+python3 -m pretalx init --no-input
+echo "------"
+echo "${GREEN}✅ Pretalx initialized.${RESET}"
+
+echo "${YELLOW}ℹ Collecting static files.${RESET}"
+echo "-----"
+python3 -m pretalx collectstatic --noinput
+echo "-----"
+echo "${GREEN}✅ Static files collected.${RESET}"
+
+echo "${YELLOW}ℹ Create dummy event.${RESET}"
+echo "-----"
+python3 -m pretalx create_test_event
+echo "-----"
+echo "${GREEN}✅ Dummy event created ${RESET}"
+
+
+# Finsih with a non-zero exit code to run default post-create.sh script.
+# In every other case, please ensure proper error handling to avoid failing with a non-zero exit code.
+exit 1;

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,30 +1,5 @@
 #!/bin/sh
 # Plugin specific post-create.sh script.
-GREEN="\033[1;32m"
-YELLOW="\033[1;33m"
-RED="\033[1;31m"
-RESET="\033[0m"
 
-echo "${YELLOW}ℹ Current working directory: $(pwd)${RESET}"
-echo "${YELLOW}ℹ Initalizing pretalx.${RESET}"
-echo "------"
-python3 -m pretalx init --no-input
-echo "------"
-echo "${GREEN}✅ Pretalx initialized.${RESET}"
-
-echo "${YELLOW}ℹ Collecting static files.${RESET}"
-echo "-----"
-python3 -m pretalx collectstatic --noinput
-echo "-----"
-echo "${GREEN}✅ Static files collected.${RESET}"
-
-echo "${YELLOW}ℹ Create dummy event.${RESET}"
-echo "-----"
-python3 -m pretalx create_test_event
-echo "-----"
-echo "${GREEN}✅ Dummy event created ${RESET}"
-
-
-# Finsih with a non-zero exit code to run default post-create.sh script.
-# In every other case, please ensure proper error handling to avoid failing with a non-zero exit code.
-exit 1;
+echo "Nothing to do";
+exit 0;

--- a/.devcontainer/post-start.sh
+++ b/.devcontainer/post-start.sh
@@ -1,25 +1,5 @@
 #!/bin/sh
 # Plugin specific post-start.sh script.
 
-CFG_FILE="./.devcontainer/pretalx.cfg"
-TEMPLATE_FILE="./.devcontainer/pretalx.cfg.template"
-
-GREEN="\033[1;32m"
-YELLOW="\033[1;33m"
-RED="\033[1;31m"
-RESET="\033[0m"
-
-echo "${YELLOW}ℹ Current working directory: $(pwd)${RESET}"
-
-if [ -f "$CFG_FILE" ]; then
-  echo "${GREEN}✔ Configuration file '$CFG_FILE' already exists.${RESET}"
-else
-  if [ -f "$TEMPLATE_FILE" ]; then
-    cp "$TEMPLATE_FILE" "$CFG_FILE"
-    echo "${GREEN}⚡ Created '$CFG_FILE' from template.${RESET}"
-  else
-    echo "${RED}✖ Template file '$TEMPLATE_FILE' not found. Cannot create '$CFG_FILE'.${RESET}"
-    exit 1
-  fi
-fi
-
+echo "Nothing to do";
+exit 0;

--- a/.devcontainer/post-start.sh
+++ b/.devcontainer/post-start.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+# Plugin specific post-start.sh script.
+
+CFG_FILE="./.devcontainer/pretalx.cfg"
+TEMPLATE_FILE="./.devcontainer/pretalx.cfg.template"
+
+GREEN="\033[1;32m"
+YELLOW="\033[1;33m"
+RED="\033[1;31m"
+RESET="\033[0m"
+
+echo "${YELLOW}ℹ Current working directory: $(pwd)${RESET}"
+
+if [ -f "$CFG_FILE" ]; then
+  echo "${GREEN}✔ Configuration file '$CFG_FILE' already exists.${RESET}"
+else
+  if [ -f "$TEMPLATE_FILE" ]; then
+    cp "$TEMPLATE_FILE" "$CFG_FILE"
+    echo "${GREEN}⚡ Created '$CFG_FILE' from template.${RESET}"
+  else
+    echo "${RED}✖ Template file '$TEMPLATE_FILE' not found. Cannot create '$CFG_FILE'.${RESET}"
+    exit 1
+  fi
+fi
+

--- a/.devcontainer/pretalx.cfg.template
+++ b/.devcontainer/pretalx.cfg.template
@@ -1,0 +1,16 @@
+# This is a local configuration file to pre-configure pretalx for development inside the devcontainer.
+# Feel free to modify it for you local needs during development.
+# It serves as a "just works" baseline.
+[site]
+debug = True
+url = http://localhost:8000
+
+[authentication]
+additional_auth_backends=social_core.backends.open_id_connect.OpenIdConnectAuth
+
+[plugin:pretalx_social_auth]
+SOCIAL_AUTH_OIDC_OIDC_ENDPOINT =http://localhost:9400
+# These are dummy values for local development and will work with the local OIDC provider setup in this devcontainer.
+SOCIAL_AUTH_OIDC_KEY=local_client_id
+SOCIAL_AUTH_OIDC_SECRET=local_client_secret
+BACKEND_NAME_MAPPING={ "oidc": "Development OIDC" }

--- a/pretalx_social_auth/strategy.py
+++ b/pretalx_social_auth/strategy.py
@@ -10,6 +10,7 @@ from django.utils.encoding import force_str
 from django.utils.functional import Promise
 from django.utils.translation import get_language
 from social_core.strategy import BaseStrategy, BaseTemplateStrategy
+import json
 
 DEFAULT_SETTINGS = {
     "USER_FIELD_MAPPING": {"fullname": "name"},
@@ -31,12 +32,20 @@ plugin_cfg_settings = getattr(settings, "PLUGIN_SETTINGS", {}).get(
 )
 plugin_settings = DEFAULT_SETTINGS.copy()
 # cfg file makes all settings lowercase, so we need to convert them back to uppercase, and merge them with the defaults
-for setting_lower, default in plugin_cfg_settings.items():
+for setting_lower, value in plugin_cfg_settings.items():
     setting = setting_lower.upper()
-    if setting not in plugin_settings:
-        plugin_settings[setting] = default
+    # Try to load JSON if value is a string and looks like JSON
+    if isinstance(value, str):
+        try:
+            loaded = json.loads(value)
+            value = loaded
+        except (json.JSONDecodeError, TypeError):
+            pass
+    # Merge dicts, otherwise override
+    if setting in plugin_settings and isinstance(plugin_settings[setting], dict) and isinstance(value, dict):
+        plugin_settings[setting].update(value)
     else:
-        plugin_settings[setting].update(default)
+        plugin_settings[setting] = value
 
 
 def render_template_string(request, html, context=None):


### PR DESCRIPTION
Hello,
to ease the development environment setup for contributors, I added a [devcontainer](https://containers.dev/) specification.
This allows people to use a unified prepared environment to easily spin up a ready to use devcontainer with:

1. Pretalx automatically installed
2. Database automatically already initiated with fixed demo data - no input required.
3. A Mock OIDC provider to easily test logins.

Best regards