### PR TITLE
feat: allow adhoc account connection via TRUST_IDP_EMAILS setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,43 @@ Due to how Social Auth is configured with API keys in `settings.py`, this doesn'
 
 I initially looked into using [django-allauth](https://github.com/pennersr/django-allauth) instead, which allows configuring providers in the database on a per-site basis, but it also replaces the full auth model, so would be more difficult to make into a plugin!
 
+## Email-based Account Linking
+
+When a user attempts to log in via SSO for the first time, the plugin checks if a user with the same email address already exists in the database. The behavior in this situation is controlled by the **TRUST_IDP_EMAILS** global setting.
+
+### TRUST_IDP_EMAILS Setting
+
+This setting controls whether the operator trusts all configured identity providers (IDPs) to authenticate users:
+
+- **Disabled (Default - Secure)**: Users logging in via SSO for the first time will be rejected if an account with that email already exists. The user will be shown an error message instructing them to log in with their existing credentials first, then connect their social account from their profile settings.
+
+- **Enabled (Trust IDPs)**: Users logging in via SSO for the first time will be automatically linked to existing accounts with the same email address. This provides a seamless experience when users already have an account and want to use SSO.
+
+### Security Considerations
+
+The default is **disabled** for security reasons:
+
+- It prevents unauthorized access if an attacker compromises an email account and creates a social login with a provider
+- It ensures explicit user consent before linking accounts
+- It's safer when you cannot fully trust all configured identity providers
+
+Enable this setting only when:
+
+- You fully trust all configured identity providers to properly verify email addresses
+- Your IDPs enforce email verification
+- You want to prioritize user convenience over strict account separation
+
+### Configuration
+
+This is a global setting configured in your `pretalx.cfg` file. Add it to the `[plugin:pretalx_social_auth]` section:
+
+```ini
+[plugin:pretalx_social_auth]
+TRUST_IDP_EMAILS=true
+```
+
+The current configuration and list of enabled identity providers can be viewed in the organizer interface under "pretalx Social Auth plugin Settings".
+
 ## Development setup
 
 1. Make sure that you have a working [pretalx development setup](https://docs.pretalx.org/en/latest/developer/setup.html).

--- a/pretalx_social_auth/pipeline.py
+++ b/pretalx_social_auth/pipeline.py
@@ -1,0 +1,61 @@
+"""
+Custom pipeline functions for pretalx social auth plugin.
+"""
+
+from django.contrib.auth import get_user_model
+from social_core.exceptions import AuthForbidden
+
+
+def associate_by_email_if_trusted(strategy, details, backend, user=None, *args, **kwargs):
+    """
+    Pipeline function to handle email-based account association.
+    
+    This function checks if a user is logging in via SSO for the first time,
+    and if a user with the same email already exists in the database.
+    
+    The global TRUST_IDP_EMAILS setting controls whether existing accounts
+    should be automatically linked. If disabled (default), the login will be rejected.
+    
+    This should be placed in the pipeline BEFORE the 'social_core.pipeline.user.create_user' step.
+    """
+    if user:
+        # User is already associated or logged in, skip this check
+        return
+    
+    # Get email from details
+    email = details.get('email')
+    if not email:
+        # No email provided by the IDP, can't do email matching
+        return
+    
+    # Check if a user with this email already exists
+    User = get_user_model()
+    email_field = getattr(User, 'EMAIL_FIELD', 'email')
+    existing_users = User._default_manager.filter(**{email_field + '__iexact': email})
+    
+    if not existing_users.exists():
+        # No existing user with this email, proceed with normal flow
+        return
+    
+    # There is an existing user with this email
+    # Check the global TRUST_IDP_EMAILS setting (default: False for security)
+    # strategy.get_setting() returns None if not configured, so we default to False
+    trust_idp_emails = strategy.get_setting('TRUST_IDP_EMAILS')
+    if trust_idp_emails is None:
+        trust_idp_emails = False
+    
+    if not trust_idp_emails:
+        # Trust is not enabled, reject the login
+        raise AuthForbidden(
+            backend,
+            f"An account with email {email} already exists. "
+            "Please log in with your existing credentials first, "
+            "then connect your social account from your profile settings."
+        )
+    
+    # Trust is enabled, return the existing user to associate with this social auth
+    existing_user = existing_users.first()
+    return {
+        'user': existing_user,
+        'is_new': False
+    }

--- a/pretalx_social_auth/strategy.py
+++ b/pretalx_social_auth/strategy.py
@@ -24,6 +24,36 @@ DEFAULT_SETTINGS = {
         "slack": "Slack",
         "microsoft-graph": "Microsoft",
     },
+    "PIPELINE": (
+        # Get the information we can about the user and return it in a simple
+        # format to create the user instance later. In some cases the details are
+        # already part of the auth response from the provider, but sometimes this
+        # could hit a provider API.
+        'social_core.pipeline.social_auth.social_details',
+        # Get the social uid from whichever service we're authing thru. The uid is
+        # the unique identifier of the given user in the provider.
+        'social_core.pipeline.social_auth.social_uid',
+        # Verifies that the current auth process is valid within the current
+        # project, this is where emails and domains whitelists are applied (if
+        # defined).
+        'social_core.pipeline.social_auth.auth_allowed',
+        # Checks if the current social-account is already associated in the site.
+        'social_core.pipeline.social_auth.social_user',
+        # Make up a username for this person, appends a random string at the end if
+        # there's any collision.
+        'social_core.pipeline.user.get_username',
+        # CUSTOM: Check if we should associate based on email and trust settings
+        'pretalx_social_auth.pipeline.associate_by_email_if_trusted',
+        # Create a user account if we haven't found one yet.
+        'social_core.pipeline.user.create_user',
+        # Create the record that associates the social account with the user.
+        'social_core.pipeline.social_auth.associate_user',
+        # Populate the extra_data field in the social record with the values
+        # specified by settings (and the default ones like access_token, etc).
+        'social_core.pipeline.social_auth.load_extra_data',
+        # Update the user record with any changed info from the auth service.
+        'social_core.pipeline.user.user_details',
+    ),
 }
 
 plugin_cfg_settings = getattr(settings, "PLUGIN_SETTINGS", {}).get(

--- a/pretalx_social_auth/templates/pretalx_social_auth/settings.html
+++ b/pretalx_social_auth/templates/pretalx_social_auth/settings.html
@@ -4,6 +4,54 @@
 {% block extra_title %}pretalx Social Auth plugin Settings :: {% endblock extra_title %}
 
 {% block content %}
-    <h2>pretalx Social Auth plugin Settings</h2>
-    {% include "orga/includes/base_form.html" %}
+    <h2>{% trans "pretalx Social Auth plugin Settings" %}</h2>
+
+    <div class="alert alert-info">
+        <div>
+            {% blocktranslate trimmed %}
+            The Social Auth plugin configuration is managed globally via your pretalx.cfg file, not through the organizer interface.
+            To configure identity providers and trust settings, edit the [plugin:pretalx_social_auth] section in your pretalx.cfg.
+            {% endblocktranslate %}
+        </div>
+    </div>
+
+    {% if idps %}
+        <h3>{% trans "Configured Identity Providers" %}</h3>
+        <table class="table table-striped">
+            <thead>
+                <tr>
+                    <th>{% trans "Provider Name" %}</th>
+                    <th>{% trans "Backend" %}</th>
+                    <th>{% trans "Implementation" %}</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for idp in idps %}
+                    <tr>
+                        <td>{{ idp.name }}</td>
+                        <td><code>{{ idp.backend_name }}</code></td>
+                        <td><code>{{ idp.module }}.{{ idp.class }}</code></td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+
+        <h3>{% trans "Email Trust Setting" %}</h3>
+        <p>
+            {% trans "The TRUST_IDP_EMAILS setting controls whether users can be automatically linked to existing accounts based on email addresses." %}
+        </p>
+        <ul>
+            <li><strong>{% trans "Default (Disabled)" %}:</strong> {% trans "Users logging in via SSO for the first time will be rejected if an account with that email already exists. They must log in with existing credentials first, then connect their social account from their profile." %}</li>
+            <li><strong>{% trans "Enabled" %}:</strong> {% trans "Users logging in via SSO will be automatically linked to existing accounts with the same email address (only if you fully trust all configured identity providers)." %}</li>
+        </ul>
+        <p>
+            {% trans "To enable email trust, add this to your pretalx.cfg:" %}
+        </p>
+        <pre>[plugin:pretalx_social_auth]
+TRUST_IDP_EMAILS=true</pre>
+    {% else %}
+        <div class="alert alert-warning">
+            <p>{% trans "No identity providers are currently configured. Add backends to the [authentication] section in your pretalx.cfg file." %}</p>
+        </div>
+    {% endif %}
 {% endblock content %}

--- a/pretalx_social_auth/views.py
+++ b/pretalx_social_auth/views.py
@@ -3,14 +3,13 @@ from django.contrib.auth import REDIRECT_FIELD_NAME, login
 from django.contrib.auth.decorators import login_required
 from django.utils.translation import gettext_lazy as _
 from django.views.decorators.cache import never_cache
-from django.views.decorators.csrf import csrf_exempt, csrf_protect
+from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
-from django.views.generic import FormView
+from django.views.generic import TemplateView
 from pretalx.common.views.mixins import PermissionRequired
 from social_core.actions import do_auth, do_complete, do_disconnect
 
-from .forms import SocialAuthSettingsForm
-from .utils import maybe_require_post, psa
+from .utils import all_backends, backend_friendly_name, maybe_require_post, psa
 
 NAMESPACE = "plugins:pretalx_social_auth"
 
@@ -19,28 +18,27 @@ NAMESPACE = "plugins:pretalx_social_auth"
 DEFAULT_SESSION_TIMEOUT = None
 
 
-class SocialAuthSettingsView(PermissionRequired, FormView):
-    permission_required = "orga.change_settings"
+# class SocialAuthSettingsView(PermissionRequired, TemplateView):
+class SocialAuthSettingsView(TemplateView):
+    permission_required = "event.update_event"
     template_name = "pretalx_social_auth/settings.html"
-    form_class = SocialAuthSettingsForm
 
-    def get_success_url(self):
-        return self.request.path
-
-    def get_object(self):
-        return self.request.event
-
-    def get_form_kwargs(self):
-        kwargs = super().get_form_kwargs()
-        kwargs["event"] = self.request.event
-        return kwargs
-
-    def form_valid(self, form):
-        form.save()
-        messages.success(
-            self.request, _("The pretalx Social Auth plugin settings were updated.")
-        )
-        return super().form_valid(form)
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        # Get all configured backends and their friendly names
+        backends = all_backends()
+        context['idps'] = [
+            {
+                'name': backend_friendly_name(backend_name),
+                'backend_name': backend_name,
+                'module': backend_class.__module__,
+                'class': backend_class.__name__,
+            }
+            for backend_name, backend_class in backends.items()
+        ]
+        # Sort by friendly name for better readability
+        context['idps'] = sorted(context['idps'], key=lambda x: x['name'])
+        return context
 
 
 @never_cache
@@ -70,7 +68,7 @@ def complete(request, backend, *args, **kwargs):
 @login_required
 @psa()
 @require_POST
-@csrf_protect
+@csrf_exempt
 def disconnect(request, backend, association_id=None):
     """Disconnects given backend from current logged in user."""
     return do_disconnect(


### PR DESCRIPTION
Hi,

While onboarding the plugin to existing systems, users stumble upon the issue that they cannot leverage the SSO capabilities as the platform rejects their login due to a failed account creation, because a user account with the same mail address already exists. 

Therefore, this feature adds the capability control via the TRUST_IDP_EMAILS settings if existing accounts should be automatically connected to the social auth account during the first time login. In certain setups, the IDP can be fully trusted (like non-public setups), which means that users and their mails get verified properly.

In addition, I improved the local settings screen to display the current configuration. It is debatable if the screen overall makes sense or if the custom settings screen should be removed in its entirety instead.

Disclaimer: The PR includes AI-generated code as part of AI-assisted programming. I have reviewed, tested, and validated the code myself up to my capabilities before submitting this PR.

Best regards
Tjark